### PR TITLE
Give test_dir() a recursive option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: testthat
 Title: Unit Testing for R
-Version: 3.1.6.9000
+Version: 3.1.6.9001
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
     person("RStudio", role = c("cph", "fnd")),

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -49,6 +49,7 @@
 #' @param stop_on_failure If `TRUE`, throw an error if any tests fail.
 #' @param stop_on_warning If `TRUE`, throw an error if any tests generate
 #'   warnings.
+#' @param recursive If `TRUE` Test that will search for test files in the nested directories.
 #' @param load_package Strategy to use for load package code:
 #'   * "none", the default, doesn't load the package.
 #'   * "installed", uses [library()] to load an installed package.
@@ -75,6 +76,7 @@ test_dir <- function(path,
                      stop_on_warning = FALSE,
                      wrap = lifecycle::deprecated(),
                      package = NULL,
+                     recursive = FALSE,
                      load_package = c("none", "installed", "source")
                      ) {
 
@@ -86,7 +88,8 @@ test_dir <- function(path,
     filter = filter,
     ...,
     full.names = FALSE,
-    start_first = start_first
+    start_first = start_first,
+    recursive = recursive
   )
   if (length(test_paths) == 0) {
     abort("No test files found")
@@ -370,8 +373,8 @@ local_teardown_env <- function(env = parent.frame()) {
 #' @return A character vector of paths
 #' @keywords internal
 #' @export
-find_test_scripts <- function(path, filter = NULL, invert = FALSE, ..., full.names = TRUE, start_first = NULL) {
-  files <- dir(path, "^test.*\\.[rR]$", full.names = full.names)
+find_test_scripts <- function(path, filter = NULL, invert = FALSE, ..., full.names = TRUE, start_first = NULL, recursive = FALSE) {
+  files <- dir(path, "^test.*\\.[rR]$", full.names = full.names, recursive = recursive)
   files <- filter_test_scripts(files, filter, invert, ...)
   order_test_scripts(files, start_first)
 }

--- a/man/find_test_scripts.Rd
+++ b/man/find_test_scripts.Rd
@@ -10,7 +10,8 @@ find_test_scripts(
   invert = FALSE,
   ...,
   full.names = TRUE,
-  start_first = NULL
+  start_first = NULL,
+  recursive = FALSE
 )
 }
 \arguments{
@@ -31,6 +32,8 @@ first pattern first,  then the ones matching the second, etc. and then
 the rest of the files, alphabetically. Parallel tests tend to finish
 quicker if you start the slowest files first. \code{NULL} means alphabetical
 order.}
+
+\item{recursive}{If \code{TRUE} Test that will search for test files in the nested directories.}
 }
 \value{
 A character vector of paths

--- a/man/test_dir.Rd
+++ b/man/test_dir.Rd
@@ -15,6 +15,7 @@ test_dir(
   stop_on_warning = FALSE,
   wrap = lifecycle::deprecated(),
   package = NULL,
+  recursive = FALSE,
   load_package = c("none", "installed", "source")
 )
 }
@@ -46,6 +47,8 @@ warnings.}
 \item{wrap}{DEPRECATED}
 
 \item{package}{If these tests belong to a package, the name of the package.}
+
+\item{recursive}{If \code{TRUE} Test that will search for test files in the nested directories.}
 
 \item{load_package}{Strategy to use for load package code:
 \itemize{


### PR DESCRIPTION
Because of this https://github.com/Appsilon/rhino/pull/440, the recursive `rhino::test_r()` PR https://github.com/Appsilon/rhino/pull/433 may not be sustainable. It works outside of `testthat`. To provide an experience similar to `testthat::test_dir()`, I just copied the stdout prompts of `ProgressReporter`. This cannot accommodate a specific reporter like `JunitReporter` or any other reporters.

This is a proposal solution inside `testthat`.

## How to test

1. `testthat::test_dir("tests/testthat/")` will work as before. Just one a single directory, and with the default reporter.
2. `testthat::test_dir("tests/testthat/", recursive = TRUE)` to run all of the test scripts in all directories in `tests/testthat`. `testthat::test_dir()` will only see scripts with the `^test.*\\.[rR]$` filename.
3. testthat::test_dir("tests/testthat/", recursive = TRUE, reporter = "Junit") the same as (2) above, but display Junit format.